### PR TITLE
Specify default bind addresses and ports for various services

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -280,6 +280,16 @@ in
         services = {
           authentik.settings = {
             blueprints_dir = mkDefault "${cfg.authentikComponents.staticWorkdirDeps}/blueprints";
+            listen = {
+              listen_debug = mkDefault "127.0.0.1:9900";
+              listen_debug_py = mkDefault "127.0.0.1:9901";
+              listen_http = mkDefault "127.0.0.1:9000";
+              listen_https = mkDefault "127.0.0.1:9443";
+              listen_ldap = mkDefault "0.0.0.0:3389";
+              listen_ldaps = mkDefault "0.0.0.0:6636";
+              listen_radius = mkDefault "0.0.0.0:1812";
+              listen_metrics = mkDefault "127.0.0.1:9300";
+            };
             template_dir = mkDefault "${cfg.authentikComponents.staticWorkdirDeps}/templates";
             postgresql = mkIf cfg.createDatabase {
               user = mkDefault "authentik";


### PR DESCRIPTION
Addresses #71 .

Without this we get the default behavior that is compiled in to Authentik. Authentik generally expects to run inside a container and therefore defaults to binding all available addresses. This can be surprising and dangerous when running outside of a container, so by setting these values explicitly only a few services (LDAP, LDAPS, Radius, Metrics) bind all addresses while others require the user to specify they awant possibly world-addressable services to bind all addresses.