### PR TITLE
module: set postgresql.host to /run/postgresql

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -307,7 +307,7 @@ in
             postgresql = mkIf cfg.createDatabase {
               user = mkDefault "authentik";
               name = mkDefault "authentik";
-              host = mkDefault "";
+              host = mkDefault "/run/postgresql";
             };
             cert_discovery_dir = mkIf (cfg.nginx.enable && cfg.nginx.enableACME) "env://CREDENTIALS_DIRECTORY";
             storage.media = {


### PR DESCRIPTION
Closes #79

So apparently the Python-based server knew to use `/run/postgresql` if `host` is empty, but the Go driver tripped over it. Use this explicitly to fix both cases.

cc @hexchen