### PR TITLE
update: 2025.12.1 -> 2025.12.3

### DIFF
--- a/components/0002-admin-file-dir-doesn-t-have-to-be-a-mountpoint.patch
+++ b/components/0002-admin-file-dir-doesn-t-have-to-be-a-mountpoint.patch
@@ -1,20 +1,20 @@
-From 2f51711b64204d090ad8cd6b2ef19fd11a1a6469 Mon Sep 17 00:00:00 2001
+From 18b41fcb663a11fcd8ccc27bd951cc150456291b Mon Sep 17 00:00:00 2001
 From: Maximilian Bosch <maximilian@mbosch.me>
 Date: Fri, 16 Jan 2026 21:50:11 +0100
-Subject: [PATCH 2/2] admin: file dir doesn't have to be a mountpoint
+Subject: [PATCH] admin: file dir doesn't have to be a mountpoint
 
 ---
  authentik/admin/files/backends/file.py | 1 -
  1 file changed, 1 deletion(-)
 
 diff --git a/authentik/admin/files/backends/file.py b/authentik/admin/files/backends/file.py
-index 7858ed5e9b..8a6d55ce64 100644
+index 6d60d5f236..720223231f 100644
 --- a/authentik/admin/files/backends/file.py
 +++ b/authentik/admin/files/backends/file.py
-@@ -47,7 +47,6 @@ class FileBackend(ManageableBackend):
-     def manageable(self) -> bool:
+@@ -52,7 +52,6 @@ class FileBackend(ManageableBackend):
+         # file creation on fresh installs.
          return (
-             self.base_path.exists()
+             self._base_dir.exists()
 -            and (self._base_dir.is_mount() or (self._base_dir / self.usage.value).is_mount())
              or (settings.DEBUG or settings.TEST)
          )

--- a/components/client-go.nix
+++ b/components/client-go.nix
@@ -1,0 +1,20 @@
+{
+  authentik-src,
+  authentik-go,
+  openapi-generator-cli,
+  runCommand,
+}:
+
+runCommand "go-client-code" {
+  nativeBuildInputs = [
+    openapi-generator-cli
+  ];
+} ''
+  cp --no-preserve=mode -vr ${authentik-go}/ $out/
+  cp -vr ${authentik-src}/schema.yml $out/
+  pushd $out &>/dev/null
+    substituteInPlace config.yaml \
+      --replace-fail "templateDir: /local/templates/" "templateDir: ./templates/"
+    openapi-generator-cli generate -i schema.yml -g go -o . -c config.yaml
+  popd &>/dev/null
+''

--- a/flake.lock
+++ b/flake.lock
@@ -1,18 +1,34 @@
 {
   "nodes": {
-    "authentik-src": {
+    "authentik-go": {
       "flake": false,
       "locked": {
-        "lastModified": 1768596569,
-        "narHash": "sha256-HDTbQB/sMhYh2b95dQwzF8OgrwLWdl4hVmx6wtDcgE8=",
-        "owner": "ma27",
-        "repo": "authentik",
-        "rev": "72ad5fe320f2201fc2a37372d4c9cb46377a58e5",
+        "lastModified": 1770333754,
+        "narHash": "sha256-Yyna75Nd6485tZP9IpdEa5QNomswe9hRfM+w3MuET9E=",
+        "owner": "goauthentik",
+        "repo": "client-go",
+        "rev": "280022b0a8de5c8f4b2965d1147a1c4fa846ba64",
         "type": "github"
       },
       "original": {
-        "owner": "ma27",
-        "ref": "2025.12.1-dependency-fix",
+        "owner": "goauthentik",
+        "repo": "client-go",
+        "type": "github"
+      }
+    },
+    "authentik-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770055313,
+        "narHash": "sha256-t9DOFNSQJZdUnZSEr3z8EBRsltS4DKu9xad9gS5/Ikc=",
+        "owner": "goauthentik",
+        "repo": "authentik",
+        "rev": "6760f4c5d38e245edb72e12e4f45bda8dd859ccd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "goauthentik",
+        "ref": "version/2025.12.3",
         "repo": "authentik",
         "type": "github"
       }
@@ -174,6 +190,7 @@
     },
     "root": {
       "inputs": {
+        "authentik-go": "authentik-go",
         "authentik-src": "authentik-src",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,11 @@
     };
     authentik-src = {
       # change version string in outputs as well when updating
-      #url = "github:goauthentik/authentik/version/2025.12.1";
-      url = "github:ma27/authentik/2025.12.1-dependency-fix";
+      url = "github:goauthentik/authentik/version/2025.12.3";
+      flake = false;
+    };
+    authentik-go = {
+      url = "github:goauthentik/client-go";
       flake = false;
     };
   };
@@ -54,6 +57,7 @@
       flake-parts,
       napalm,
       authentik-src,
+      authentik-go,
       uv2nix,
       pyproject-build-systems,
       pyproject-nix,
@@ -68,7 +72,7 @@
         ...
       }:
       let
-        authentik-version = "2025.12.1"; # to pass to the drvs of some components
+        authentik-version = "2025.12.3"; # to pass to the drvs of some components
       in
       {
         systems = import inputs.systems;
@@ -127,6 +131,8 @@
                   manage = final.callPackage ./components/manage.nix { };
                 };
 
+                generatedGoClient = final.callPackage ./components/client-go.nix { };
+
                 # for uv2nix
                 pythonOverlay = final.callPackage ./components/python-overrides.nix { };
 
@@ -136,6 +142,7 @@
 
                 inherit
                   authentik-src
+                  authentik-go
                   authentik-version
                   buildNapalmPackage
                   uv2nix


### PR DESCRIPTION
Closes #90

ChangeLogs:
* https://github.com/goauthentik/authentik/releases/tag/version%2F2025.12.2
* https://github.com/goauthentik/authentik/releases/tag/version%2F2025.12.3

Using the `client-go` library that is vendored in this release's `go.mod` breaks all outposts for me, so we're now doing what upstream is also doing, i.e. generating the Go client code ourselves.

cc @riotbib @MarcelCoding 