### PR TITLE
docs: fix build in non sandboxed mode

### DIFF
--- a/components/docs.nix
+++ b/components/docs.nix
@@ -20,8 +20,8 @@ buildNapalmPackage "${authentik-src}/website" {
   ];
   installPhase = ''
     rm -f ../website/static/blueprints
-    mv -v ../website $out
-    cp -vr ../blueprints $out/static/blueprints
+    cp -vr ../blueprints ../website/static/blueprints
+    cp -vr ../website $out
   '';
 
   # These are lockfiles with extra deps that are required to successfully build


### PR DESCRIPTION
When building with sandbox disabled. The build path is a TMP directory instead of mounted at `/build`. Moving  `../website` which is also the current working directory also moves the current working directory when sandbox is disabled. Now the copy of the blueprints fails as the current working directory is some nix store path instead of the build directory. 
Switching both commands fixes this issue.