### PR TITLE
update: 2026.2 -> 2026.2.1

### DIFF
--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -69,7 +69,7 @@ buildGo125Module {
   ] ++ lib.optionals guacamoleAvailable [
     "cmd/rac"
   ];
-  vendorHash = "sha256-0YKn6qScUjkLOq/hyUZp7e+dQ58POSgj4CgfDro+5J4=";
+  vendorHash = "sha256-8dCw7CBPboUhx/mNpD/ml6w4DsStDNEFkRtOagsDEgk=";
   nativeBuildInputs = [ makeWrapper ];
   doCheck = false;
   postInstall = ''

--- a/flake.lock
+++ b/flake.lock
@@ -19,16 +19,16 @@
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1771963976,
-        "narHash": "sha256-pVQ34cZYX3hlk6hF1aZ/n32xMqTF4Jmp0G0VGDU7iXc=",
+        "lastModified": 1772567399,
+        "narHash": "sha256-0Vpf1hj9C8r+rhrCgwoNazpQ+mwgjdjDhuoKCxYQFWw=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "8af491630b70ff6bd089753e21bef511bfb3f557",
+        "rev": "0dccbd4193c45c581e9fb7cd89df0c1487510f1f",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2026.2.0",
+        "ref": "version/2026.2.1",
         "repo": "authentik",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
     };
     authentik-src = {
       # change version string in outputs as well when updating
-      url = "github:goauthentik/authentik/version/2026.2.0";
+      url = "github:goauthentik/authentik/version/2026.2.1";
       flake = false;
     };
     authentik-go = {
@@ -72,7 +72,7 @@
         ...
       }:
       let
-        authentik-version = "2026.2.0"; # to pass to the drvs of some components
+        authentik-version = "2026.2.1"; # to pass to the drvs of some components
       in
       {
         systems = import inputs.systems;


### PR DESCRIPTION
ChangeLog: https://docs.goauthentik.io/releases/2026.2/#fixed-in-202621

@ma27, presenting my first version bump for `authentik-nix` as a draft PR.

Not tested, as I'd only have our production deployment right now. But it builds succesfully using `nix flake check`.

If you take another look, I can test this branch right after.

I took inspiration in your previous commits, that bump authentik on patch version level.