### PR TITLE
update: 2026.2.1 -> 2026.2.2

### DIFF
--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -69,7 +69,7 @@ buildGo125Module {
   ] ++ lib.optionals guacamoleAvailable [
     "cmd/rac"
   ];
-  vendorHash = "sha256-8dCw7CBPboUhx/mNpD/ml6w4DsStDNEFkRtOagsDEgk=";
+  vendorHash = "sha256-Gf80rt86Qc6gg/ec8++U9uNW1KQEkwKt+CFN82KV1f8=";
   nativeBuildInputs = [ makeWrapper ];
   doCheck = false;
   postInstall = ''

--- a/flake.lock
+++ b/flake.lock
@@ -19,16 +19,16 @@
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1772567399,
-        "narHash": "sha256-0Vpf1hj9C8r+rhrCgwoNazpQ+mwgjdjDhuoKCxYQFWw=",
+        "lastModified": 1775573258,
+        "narHash": "sha256-Xq7JGI/8ppIydIuWd9KRJKUrh7UpeniwvZ4NAtXbYJ4=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "0dccbd4193c45c581e9fb7cd89df0c1487510f1f",
+        "rev": "5249546862986202b901c2afd860992ec48c6ef6",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2026.2.1",
+        "ref": "version/2026.2.2",
         "repo": "authentik",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
     };
     authentik-src = {
       # change version string in outputs as well when updating
-      url = "github:goauthentik/authentik/version/2026.2.1";
+      url = "github:goauthentik/authentik/version/2026.2.2";
       flake = false;
     };
     authentik-go = {
@@ -72,7 +72,7 @@
         ...
       }:
       let
-        authentik-version = "2026.2.1"; # to pass to the drvs of some components
+        authentik-version = "2026.2.2"; # to pass to the drvs of some components
       in
       {
         systems = import inputs.systems;


### PR DESCRIPTION
Bumps authentik to the latest version.
Changelog: https://docs.goauthentik.io/releases/2026.2#fixed-in-202622
