### PR TITLE
update: 2026.2.2 -> 2026.2.3

### DIFF
--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -69,7 +69,7 @@ buildGo125Module {
   ] ++ lib.optionals guacamoleAvailable [
     "cmd/rac"
   ];
-  vendorHash = "sha256-Gf80rt86Qc6gg/ec8++U9uNW1KQEkwKt+CFN82KV1f8=";
+  vendorHash = "sha256-Rz6qSQjcTcwJy94fs6MDx/M/dfPxe7V2GTu7/ugvFTA=";
   nativeBuildInputs = [ makeWrapper ];
   doCheck = false;
   postInstall = ''

--- a/flake.lock
+++ b/flake.lock
@@ -19,16 +19,16 @@
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1775573258,
-        "narHash": "sha256-Xq7JGI/8ppIydIuWd9KRJKUrh7UpeniwvZ4NAtXbYJ4=",
+        "lastModified": 1778615640,
+        "narHash": "sha256-tTBGwajdtEPuk36va5HgnnqR8sTuSwIt/c48bIinRlA=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "5249546862986202b901c2afd860992ec48c6ef6",
+        "rev": "095e2897d52397962d153be2d689cedcdb71906c",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2026.2.2",
+        "ref": "version/2026.2.3",
         "repo": "authentik",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
     };
     authentik-src = {
       # change version string in outputs as well when updating
-      url = "github:goauthentik/authentik/version/2026.2.2";
+      url = "github:goauthentik/authentik/version/2026.2.3";
       flake = false;
     };
     authentik-go = {
@@ -72,7 +72,7 @@
         ...
       }:
       let
-        authentik-version = "2026.2.2"; # to pass to the drvs of some components
+        authentik-version = "2026.2.3"; # to pass to the drvs of some components
       in
       {
         systems = import inputs.systems;


### PR DESCRIPTION
Changelog: https://github.com/goauthentik/authentik/releases/tag/version%2F2026.2.3
Release notes: https://docs.goauthentik.io/releases/2026.2#fixed-in-202623

No important breaking changes as far as I can see.

Fixes security issues: CVE-2026-40165, CVE-2026-40166, CVE-2026-40172, CVE-2026-41569, CVE-2026-41577, CVE-2026-42849

Partially supersedes #114.
