### PR TITLE
Flake update & project maintenance

### DIFF
--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -69,7 +69,7 @@ buildGo125Module {
   ] ++ lib.optionals guacamoleAvailable [
     "cmd/rac"
   ];
-  vendorHash = "sha256-Rz6qSQjcTcwJy94fs6MDx/M/dfPxe7V2GTu7/ugvFTA=";
+  vendorHash = "sha256-z/DAULXxj1xpaZxWiUa0GKJjVAYMLodqCQs9euQ/cpk=";
   nativeBuildInputs = [ makeWrapper ];
   doCheck = false;
   postInstall = ''

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "authentik-go": {
       "flake": false,
       "locked": {
-        "lastModified": 1771856219,
-        "narHash": "sha256-zTEmvxe+BpfWYvAl675PnhXCH4jV4GUTFb1MrQ1Eyno=",
+        "lastModified": 1778672763,
+        "narHash": "sha256-K0dzj+GnajGz63Gp+NYyhanjhtDxpzCKpmdIZYMfz/M=",
         "owner": "goauthentik",
         "repo": "client-go",
-        "rev": "4c1444ee54d945fbcc5ae107b4f191ca0352023d",
+        "rev": "58f64509446aab6bc2d9b1fe36be19b5f2a3b4a8",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771423342,
-        "narHash": "sha256-7uXPiWB0YQ4HNaAqRvVndYL34FEp1ZTwVQHgZmyMtC8=",
+        "lastModified": 1776659114,
+        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "04e9c186e01f0830dad3739088070e4c551191a4",
+        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771518446,
-        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
+        "lastModified": 1776715674,
+        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
+        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777895960,
-        "narHash": "sha256-KebDsQd+A7pm++Tp0744EjULttHvz1wbKqNKkMA/088=",
+        "lastModified": 1778664018,
+        "narHash": "sha256-ogNyNANNLo0SMFevIeUpbTMOL9uUDu/hXvp7JlOYbwQ=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "5ad90d48b80ecc920ca2247d53f46beba302e186",
+        "rev": "b48abe99ef639cd100c224898529370e5d935294",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -176,15 +176,15 @@
 
               terraform-provider-authentik = inputs.nixpkgs.legacyPackages.${system}.buildGoModule rec {
                 pname = "terraform-provider-authentik";
-                version = "2025.12.0";
+                version = "2026.2.0";
                 src = pkgs.fetchFromGitHub {
                   owner = "goauthentik";
                   repo = pname;
-                  rev = "v${version}";
-                  sha256 = "sha256-1a8HaOqTckkbbHLM58L+LY1eCp8+sVkuOmAw7xljpTU=";
+                  tag = "v${version}";
+                  hash = "sha256-a4V9bc7Xwq43Ld5Uey40+1BUUS9RFT2yqd0ZdILwsSE=";
                 };
                 doCheck = false; # tests are run against authentik -> vm test
-                vendorHash = "sha256-LvXWlmCBXnHElZyTKpKPwfXgT53HpR+Bc5XjkB7bM/A=";
+                vendorHash = "sha256-usaz9EKOCbTV2QEKWvCOdYDY2ieQOR5OZqU/S9PU1V0=";
                 postInstall = ''
                   path="$out/libexec/terraform-providers/registry.terraform.io/goauthentik/authentik/${version}/''${GOOS}_''${GOARCH}/"
                   mkdir -p "$path"

--- a/tests/minimal-vmtest.nix
+++ b/tests/minimal-vmtest.nix
@@ -59,7 +59,7 @@ pkgs.testers.runNixOSTest {
     authentik.wait_until_succeeds("curl -fL http://localhost:9000/if/flow/initial-setup/ >&2")
 
     with subtest("Frontend renders"):
-        machine.succeed("su - alice -c 'firefox http://localhost:9000/if/flow/initial-setup/' >&2 &")
+        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
         machine.wait_for_text("Welcome to authentik")
         machine.screenshot("1_rendered_frontend")
 
@@ -77,7 +77,7 @@ pkgs.testers.runNixOSTest {
         machine.screenshot("2_initial_setup_successful")
 
     with subtest("admin settings render and version as expected"):
-        machine.succeed("su - alice -c 'firefox http://localhost:9000/if/admin/' >&2 &")
+        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/admin/' >&2 &")
         machine.wait_for_text("General system status")
         machine.screenshot("3_rendered_admin_interface")
         machine.succeed("su - alice -c 'xdotool click 1' >&2")
@@ -88,7 +88,7 @@ pkgs.testers.runNixOSTest {
         machine.screenshot("4_correct_version_in_admin_interface")
 
     with subtest("nginx proxies to authentik"):
-        machine.succeed("su - alice -c 'firefox http://localhost/' >&2 &")
+        machine.succeed("su - alice -c 'firefox --kiosk http://localhost/' >&2 &")
         machine.wait_for_text("authentik")
         machine.screenshot("5_nginx_proxies_requests")
 

--- a/tests/minimal-vmtest.nix
+++ b/tests/minimal-vmtest.nix
@@ -59,44 +59,44 @@ pkgs.testers.runNixOSTest {
     authentik.wait_until_succeeds("curl -fL http://localhost:9000/if/flow/initial-setup/ >&2")
 
     with subtest("Frontend renders"):
-        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
-        machine.wait_for_text("Welcome to authentik")
-        machine.screenshot("1_rendered_frontend")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
+        authentik.wait_for_text("Welcome to authentik")
+        authentik.screenshot("1_rendered_frontend")
 
     with subtest("admin account setup works"):
-        machine.send_key("tab")
-        machine.send_key("tab")
-        machine.send_chars("akadmin@localhost")
-        machine.send_key("tab")
-        machine.send_chars("foobar")
-        machine.send_key("tab")
-        machine.send_chars("foobar")
-        machine.send_key("ret")
-        machine.wait_for_text("My applications")
-        machine.send_key("esc")
-        machine.screenshot("2_initial_setup_successful")
+        authentik.send_key("tab")
+        authentik.send_key("tab")
+        authentik.send_chars("akadmin@localhost")
+        authentik.send_key("tab")
+        authentik.send_chars("foobar")
+        authentik.send_key("tab")
+        authentik.send_chars("foobar")
+        authentik.send_key("ret")
+        authentik.wait_for_text("My applications")
+        authentik.send_key("esc")
+        authentik.screenshot("2_initial_setup_successful")
 
     with subtest("admin settings render and version as expected"):
-        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/admin/' >&2 &")
-        machine.wait_for_text("General system status")
-        machine.screenshot("3_rendered_admin_interface")
-        machine.succeed("su - alice -c 'xdotool click 1' >&2")
-        machine.succeed("su - alice -c 'xdotool key --delay 100 Page_Down' >&2")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/admin/' >&2 &")
+        authentik.wait_for_text("General system status")
+        authentik.screenshot("3_rendered_admin_interface")
+        authentik.succeed("su - alice -c 'xdotool click 1' >&2")
+        authentik.succeed("su - alice -c 'xdotool key --delay 100 Page_Down' >&2")
         # sometimes the cursor covers the version string
-        machine.succeed("su - alice -c 'xdotool mousemove_relative 50 50' >&2")
-        machine.wait_for_text("${builtins.replaceStrings [ "." ] [ ".?" ] authentik-version}")
-        machine.screenshot("4_correct_version_in_admin_interface")
+        authentik.succeed("su - alice -c 'xdotool mousemove_relative 50 50' >&2")
+        authentik.wait_for_text("${builtins.replaceStrings [ "." ] [ ".?" ] authentik-version}")
+        authentik.screenshot("4_correct_version_in_admin_interface")
 
     with subtest("nginx proxies to authentik"):
-        machine.succeed("su - alice -c 'firefox --kiosk http://localhost/' >&2 &")
-        machine.wait_for_text("authentik")
-        machine.screenshot("5_nginx_proxies_requests")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost/' >&2 &")
+        authentik.wait_for_text("authentik")
+        authentik.screenshot("5_nginx_proxies_requests")
 
     with subtest("metrics & worker"):
-        machine.wait_for_open_port(9300)
-        machine.wait_for_open_port(9301)
+        authentik.wait_for_open_port(9300)
+        authentik.wait_for_open_port(9301)
 
-        print(machine.succeed("curl -L localhost:9300/metrics | grep authentik_outpost_connection | grep 'Embedded'"))
-        print(machine.succeed("curl -L localhost:9301/metrics | grep authentik_tasks_total"))
+        print(authentik.succeed("curl -L localhost:9300/metrics | grep authentik_outpost_connection | grep 'Embedded'"))
+        print(authentik.succeed("curl -L localhost:9301/metrics | grep authentik_tasks_total"))
   '';
 }

--- a/tests/override-scope.nix
+++ b/tests/override-scope.nix
@@ -100,7 +100,7 @@ pkgs.testers.runNixOSTest {
     authentik.wait_until_succeeds("curl -fL http://localhost:9000/if/flow/initial-setup/ >&2")
 
     with subtest("Frontend renders"):
-        machine.succeed("su - alice -c 'firefox http://localhost:9000/if/flow/initial-setup/' >&2 &")
+        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
         machine.wait_for_text("${customWelcome}")
         machine.screenshot("1_rendered_frontend")
 
@@ -118,7 +118,7 @@ pkgs.testers.runNixOSTest {
         machine.screenshot("2_initial_setup_successful")
 
     with subtest("admin settings render and version as expected"):
-        machine.succeed("su - alice -c 'firefox http://localhost:9000/if/admin/' >&2 &")
+        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/admin/' >&2 &")
         machine.wait_for_text("General system status")
         machine.screenshot("3_rendered_admin_interface")
         machine.succeed("su - alice -c 'xdotool click 1' >&2")
@@ -129,7 +129,7 @@ pkgs.testers.runNixOSTest {
         machine.screenshot("4_correct_version_in_admin_interface")
 
     with subtest("nginx proxies to authentik"):
-        machine.succeed("su - alice -c 'firefox http://localhost/' >&2 &")
+        machine.succeed("su - alice -c 'firefox --kiosk http://localhost/' >&2 &")
         machine.wait_for_text("authentik")
         machine.screenshot("5_nginx_proxies_requests")
   '';

--- a/tests/override-scope.nix
+++ b/tests/override-scope.nix
@@ -47,8 +47,8 @@ pkgs.testers.runNixOSTest {
   nodes = {
     authentik = {
       virtualisation = {
-        cores = 3;
-        memorySize = 3072;
+        cores = 6;
+        memorySize = 8192;
       };
       imports = [
         nixosModules.default
@@ -100,37 +100,37 @@ pkgs.testers.runNixOSTest {
     authentik.wait_until_succeeds("curl -fL http://localhost:9000/if/flow/initial-setup/ >&2")
 
     with subtest("Frontend renders"):
-        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
-        machine.wait_for_text("${customWelcome}")
-        machine.screenshot("1_rendered_frontend")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
+        authentik.wait_for_text("${customWelcome}")
+        authentik.screenshot("1_rendered_frontend")
 
     with subtest("admin account setup works"):
-        machine.send_key("tab")
-        machine.send_key("tab")
-        machine.send_chars("akadmin@localhost")
-        machine.send_key("tab")
-        machine.send_chars("foobar")
-        machine.send_key("tab")
-        machine.send_chars("foobar")
-        machine.send_key("ret")
-        machine.wait_for_text("My applications")
-        machine.send_key("esc")
-        machine.screenshot("2_initial_setup_successful")
+        authentik.send_key("tab")
+        authentik.send_key("tab")
+        authentik.send_chars("akadmin@localhost")
+        authentik.send_key("tab")
+        authentik.send_chars("foobar")
+        authentik.send_key("tab")
+        authentik.send_chars("foobar")
+        authentik.send_key("ret")
+        authentik.wait_for_text("My applications")
+        authentik.send_key("esc")
+        authentik.screenshot("2_initial_setup_successful")
 
     with subtest("admin settings render and version as expected"):
-        machine.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/admin/' >&2 &")
-        machine.wait_for_text("General system status")
-        machine.screenshot("3_rendered_admin_interface")
-        machine.succeed("su - alice -c 'xdotool click 1' >&2")
-        machine.succeed("su - alice -c 'xdotool key --delay 100 Page_Down' >&2")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/admin/' >&2 &")
+        authentik.wait_for_text("General system status")
+        authentik.screenshot("3_rendered_admin_interface")
+        authentik.succeed("su - alice -c 'xdotool click 1' >&2")
+        authentik.succeed("su - alice -c 'xdotool key --delay 100 Page_Down' >&2")
         # sometimes the cursor covers the version string
-        machine.succeed("su - alice -c 'xdotool mousemove_relative 50 50' >&2")
-        machine.wait_for_text("${builtins.replaceStrings [ "." ] [ ".?" ] authentik-version}")
-        machine.screenshot("4_correct_version_in_admin_interface")
+        authentik.succeed("su - alice -c 'xdotool mousemove_relative 50 50' >&2")
+        authentik.wait_for_text("${builtins.replaceStrings [ "." ] [ ".?" ] authentik-version}")
+        authentik.screenshot("4_correct_version_in_admin_interface")
 
     with subtest("nginx proxies to authentik"):
-        machine.succeed("su - alice -c 'firefox --kiosk http://localhost/' >&2 &")
-        machine.wait_for_text("authentik")
-        machine.screenshot("5_nginx_proxies_requests")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost/' >&2 &")
+        authentik.wait_for_text("authentik")
+        authentik.screenshot("5_nginx_proxies_requests")
   '';
 }


### PR DESCRIPTION
* Contains a flake.lock update & addresses deprecation warnings in the VM test
* Pulls in a fix for flakyness after the last flake update (firefox kiosk mode)
* Updates the terraform provider

The last two things were done by @MarcelCoding. The change did similar things that I was doing, hence I picked the parts my branch was missing.

Closes #114 