### PR TITLE
update: 2026.2.4 -> 2026.5.2

### DIFF
--- a/components/client-go.nix
+++ b/components/client-go.nix
@@ -1,6 +1,5 @@
 {
   authentik-src,
-  authentik-go,
   openapi-generator-cli,
   runCommand,
 }:
@@ -10,11 +9,9 @@ runCommand "go-client-code" {
     openapi-generator-cli
   ];
 } ''
-  cp --no-preserve=mode -vr ${authentik-go}/ $out/
+  cp --no-preserve=mode -vr ${authentik-src}/packages/client-go/ $out/
   cp -vr ${authentik-src}/schema.yml $out/
   pushd $out &>/dev/null
-    substituteInPlace config.yaml \
-      --replace-fail "templateDir: /local/templates/" "templateDir: ./templates/"
     openapi-generator-cli generate -i schema.yml -g go -o . -c config.yaml
   popd &>/dev/null
 ''

--- a/components/docs.nix
+++ b/components/docs.nix
@@ -2,13 +2,16 @@
   authentik-src,
   authentik-version,
   buildNapalmPackage,
-  nodejs_24,
+  nodejs_26,
 }:
 
 buildNapalmPackage "${authentik-src}/website" {
   version = authentik-version; # 0.0.0 specified upstream in package.json
   NODE_ENV = "production";
-  nodejs = nodejs_24;
+  nodejs = nodejs_26;
+  postPatch = ''
+    sed -i -e '/preinstall/d' package.json
+  '';
   npmCommands = [
     "cp -v ${authentik-src}/SECURITY.md ../SECURITY.md"
     "cp -vr ${authentik-src}/blueprints ../blueprints"
@@ -16,13 +19,17 @@ buildNapalmPackage "${authentik-src}/website" {
     "mkdir -p ../lifecycle/container"
     "cp -v ${authentik-src}/lifecycle/container/compose.yml ../lifecycle/container/compose.yml"
     "npm config set loglevel verbose"
-    "npm ci --workspaces --include-workspace-root --no-audit"
+    "npm ci --workspaces --include-workspace-root --no-audit --legacy-peer-deps"
     "npm run build"
   ];
   installPhase = ''
     rm -f ../website/static/blueprints
     cp -vr ../blueprints ../website/static/blueprints
     cp -vr ../website $out
+    # remove broken symlinks we'd get a build failure for. Do this explicitly
+    # to avoid having other broken symlinks, these are not relevant for
+    # production deployments anyways.
+    rm $out/node_modules/@goauthentik/{prettier-config,tsconfig,eslint-config}
   '';
 
   # These are lockfiles with extra deps that are required to successfully build

--- a/components/frontend.nix
+++ b/components/frontend.nix
@@ -10,6 +10,7 @@ buildNapalmPackage "${authentik-src}/web" rec {
   NODE_ENV = "production";
   nodejs = nodejs_24;
   preBuild = ''
+    cp -rv --no-preserve=mode ${authentik-src}/packages ../
     ln -sv ${authentikComponents.docs} ../website
     ln -sv ${authentik-src}/package.json ../
   '';
@@ -18,6 +19,7 @@ buildNapalmPackage "${authentik-src}/web" rec {
   CHROMEDRIVER_SKIP_DOWNLOAD = "true";
   npmCommands = [
     "npm install --include=dev --nodedir=${nodejs}/include/node --loglevel verbose --ignore-scripts"
+    "(cd node_modules/@goauthentik/api && patchShebangs . && npm run build)"
     "npm run build"
     "npm run build:sfe"
   ];

--- a/components/gopkgs.nix
+++ b/components/gopkgs.nix
@@ -2,7 +2,7 @@
   authentik-src,
   authentik-version,
   authentikComponents,
-  buildGo125Module,
+  buildGo126Module,
   lib,
   makeWrapper,
   guacamole-server,
@@ -15,7 +15,7 @@ let
   guacamoleAvailable = lib.meta.availableOn stdenv.hostPlatform guacamole-server;
 
 in
-buildGo125Module {
+buildGo126Module {
   pname = "authentik-gopkgs";
   version = authentik-version;
   inherit patches;
@@ -23,9 +23,8 @@ buildGo125Module {
     sed -i"" -e 's,./web/dist/,${authentikComponents.frontend}/dist/,' web/static.go
     sed -i"" -e 's,./web/dist/,${authentikComponents.frontend}/dist/,' internal/web/static.go
     sed -i"" -e 's,./lifecycle/gunicorn.conf.py,${authentikComponents.staticWorkdirDeps}/lifecycle/gunicorn.conf.py,' internal/gounicorn/gounicorn.go
-    cp --no-preserve=mode -vr ${generatedGoClient} gen-go-api
-    echo "replace goauthentik.io/api/v3 => ./gen-go-api" >>go.mod
-    go mod edit -require=goauthentik.io/api/v3@v3.0.0
+    mkdir packages
+    cp --no-preserve=mode -vr ${generatedGoClient} packages/client-go
   '' + lib.optionalString guacamoleAvailable ''
     substituteInPlace internal/outpost/rac/guacd.go \
       --replace-fail '/opt/guacamole/sbin/guacd' \
@@ -69,7 +68,7 @@ buildGo125Module {
   ] ++ lib.optionals guacamoleAvailable [
     "cmd/rac"
   ];
-  vendorHash = "sha256-IR+mh4kAfePi7Ntb7NARpL5RNz3bNEDpDiefab4S1Zk=";
+  vendorHash = "sha256-EVDOZ4USaJoIBDB8mM4ZSBfsSc1d/NOm1Qv/hUJ+8f4=";
   nativeBuildInputs = [ makeWrapper ];
   doCheck = false;
   postInstall = ''

--- a/components/migrate.nix
+++ b/components/migrate.nix
@@ -15,9 +15,9 @@ runCommandLocal "authentik-migrate.py"
     chmod +w $out/bin/migrate.py
     patchShebangs $out/bin/migrate.py
     substituteInPlace $out/bin/migrate.py \
-      --replace \
-      'migration_path in Path(__file__).parent.absolute().glob("system_migrations/*.py")' \
-      'migration_path in Path("${authentikComponents.staticWorkdirDeps}/lifecycle").glob("system_migrations/*.py")'
+      --replace-fail \
+      'Path(__file__).parent.absolute().glob("system_migrations/*.py")' \
+      'Path("${authentikComponents.staticWorkdirDeps}/lifecycle").glob("system_migrations/*.py")'
     wrapProgram $out/bin/migrate.py \
       --prefix PATH : ${authentikComponents.pythonEnv}/bin \
       --prefix PYTHONPATH : ${authentikComponents.staticWorkdirDeps}

--- a/components/rust.nix
+++ b/components/rust.nix
@@ -1,0 +1,39 @@
+{
+  authentik-src,
+  authentik-version,
+  rustPlatform,
+  authentikComponents,
+  cmake,
+  go,
+  perl,
+  gcc13,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "authentik-rust";
+  version = authentik-version;
+  src = authentik-src;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  env.RUSTFLAGS="--cfg tokio_unstable";
+
+  cargoHash = "sha256-+vw/7bEWNc+uSTHKyzXrO9yJCK0JCrRSGJ4t5YufgIA=";
+  nativeBuildInputs = [
+    authentikComponents.pythonEnv
+    cmake
+    go
+    perl
+    gcc13
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "authentik"
+    "--no-default-features"
+    "--features"
+    "core"
+    "--locked"
+  ];
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,34 +1,18 @@
 {
   "nodes": {
-    "authentik-go": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1778672763,
-        "narHash": "sha256-K0dzj+GnajGz63Gp+NYyhanjhtDxpzCKpmdIZYMfz/M=",
-        "owner": "goauthentik",
-        "repo": "client-go",
-        "rev": "58f64509446aab6bc2d9b1fe36be19b5f2a3b4a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "goauthentik",
-        "repo": "client-go",
-        "type": "github"
-      }
-    },
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779980524,
-        "narHash": "sha256-FF44QGa0FBQACAcY7KmUdkpJuIVRNTyje1vxkQu8enM=",
+        "lastModified": 1779981174,
+        "narHash": "sha256-djsdph2E+JIIu9Sy5gJwBG378nunXXK2LPW5z/oneMs=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "d7dedc86d2f59bf958ee03c39f2cc3618347ea2f",
+        "rev": "2d26ce9b538df68b9d78dccdd5ac5bfb4c1b2983",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2026.2.4",
+        "ref": "version/2026.5.2",
         "repo": "authentik",
         "type": "github"
       }
@@ -113,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -175,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776715674,
-        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
+        "lastModified": 1778901413,
+        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
+        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
         "type": "github"
       },
       "original": {
@@ -190,7 +174,6 @@
     },
     "root": {
       "inputs": {
-        "authentik-go": "authentik-go",
         "authentik-src": "authentik-src",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",

--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,7 @@
     };
     authentik-src = {
       # change version string in outputs as well when updating
-      url = "github:goauthentik/authentik/version/2026.2.4";
-      flake = false;
-    };
-    authentik-go = {
-      url = "github:goauthentik/client-go";
+      url = "github:goauthentik/authentik/version/2026.5.2";
       flake = false;
     };
   };
@@ -57,7 +53,6 @@
       flake-parts,
       napalm,
       authentik-src,
-      authentik-go,
       uv2nix,
       pyproject-build-systems,
       pyproject-nix,
@@ -72,7 +67,7 @@
         ...
       }:
       let
-        authentik-version = "2026.2.4"; # to pass to the drvs of some components
+        authentik-version = "2026.5.2"; # to pass to the drvs of some components
       in
       {
         systems = import inputs.systems;
@@ -94,6 +89,7 @@
                         pythonEnv
                         frontend
                         gopkgs
+                        rust
                         docs
                         ;
                     }
@@ -125,6 +121,7 @@
                   pythonEnv = final.callPackage ./components/pythonEnv.nix { };
                   # server + outposts
                   gopkgs = final.callPackage ./components/gopkgs.nix { };
+                  rust = final.callPackage ./components/rust.nix { };
                   staticWorkdirDeps = final.callPackage ./components/staticWorkdirDeps.nix { };
                   migrate = final.callPackage ./components/migrate.nix { };
                   # worker
@@ -142,7 +139,6 @@
 
                 inherit
                   authentik-src
-                  authentik-go
                   authentik-version
                   buildNapalmPackage
                   uv2nix
@@ -172,6 +168,7 @@
                 staticWorkdirDeps
                 migrate
                 manage
+                rust
                 ;
 
               terraform-provider-authentik = inputs.nixpkgs.legacyPackages.${system}.buildGoModule rec {

--- a/module.nix
+++ b/module.nix
@@ -356,7 +356,10 @@ in
             requires = lib.optionals cfg.createDatabase [ "postgresql.target" ];
             wants = [ "network-online.target" ];
             after = [ "network-online.target" ] ++ lib.optionals cfg.createDatabase [ "postgresql.target" ];
-            before = [ "authentik.service" "authentik-worker.service" ];
+            before = [
+              "authentik.service"
+              "authentik-worker.service"
+            ];
             restartTriggers = [ config.environment.etc."authentik/config.yml".source ];
             environment = mkMerge [
               environment
@@ -381,7 +384,10 @@ in
             ];
           };
           authentik-worker = {
-            requires = lib.optionals cfg.createDatabase [ "postgresql.target" ];
+            requires = [
+              "authentik-migrate.service"
+            ]
+            ++ lib.optionals cfg.createDatabase [ "postgresql.target" ];
             wants = [ "network-online.target" ];
             after = [ "network-online.target" ] ++ lib.optionals cfg.createDatabase [ "postgresql.target" ];
             before = [ "authentik.service" ];
@@ -395,14 +401,16 @@ in
                 TZ = tz;
                 AUTHENTIK_LISTEN__HTTP = cfg.worker.listenHTTP;
                 AUTHENTIK_LISTEN__METRICS = cfg.worker.listenMetrics;
+                PYTHONPATH = config.services.authentik.authentikComponents.staticWorkdirDeps;
               }
             ];
+            path = [ config.services.authentik.authentikComponents.pythonEnv ];
             serviceConfig = mkMerge [
               serviceDefaults
               {
                 RuntimeDirectory = "authentik";
                 WorkingDirectory = "%t/authentik";
-                ExecStart = "${cfg.authentikComponents.manage}/bin/manage.py worker --pid-file %t/authentik/worker.pid";
+                ExecStart = "${cfg.authentikComponents.rust}/bin/authentik worker";
                 Restart = "on-failure";
                 RestartSec = "1s";
                 LoadCredential = mkIf (cfg.nginx.enable && cfg.nginx.enableACME) [
@@ -536,7 +544,7 @@ in
       {
         assertions = [
           {
-            assertion = config.services.authentik.authentikComponents.gopkgs?rac;
+            assertion = config.services.authentik.authentikComponents.gopkgs ? rac;
             message = ''
               guacamole-server is not available on the host's platform!
             '';

--- a/tests/minimal-vmtest.nix
+++ b/tests/minimal-vmtest.nix
@@ -56,10 +56,10 @@ pkgs.testers.runNixOSTest {
     authentik.wait_for_unit("authentik-worker.service")
     authentik.wait_for_unit("authentik.service")
     authentik.wait_for_open_port(9000)
-    authentik.wait_until_succeeds("curl -fL http://localhost:9000/if/flow/initial-setup/ >&2")
+    authentik.wait_until_succeeds("curl -fL http://localhost:9000/ >&2")
 
     with subtest("Frontend renders"):
-        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/' >&2 &")
         authentik.wait_for_text("Welcome to authentik")
         authentik.screenshot("1_rendered_frontend")
 
@@ -72,7 +72,7 @@ pkgs.testers.runNixOSTest {
         authentik.send_key("tab")
         authentik.send_chars("foobar")
         authentik.send_key("ret")
-        authentik.wait_for_text("My applications")
+        authentik.wait_for_text("No Applications available.")
         authentik.send_key("esc")
         authentik.screenshot("2_initial_setup_successful")
 

--- a/tests/override-scope.nix
+++ b/tests/override-scope.nix
@@ -97,10 +97,10 @@ pkgs.testers.runNixOSTest {
     authentik.wait_for_unit("authentik-worker.service")
     authentik.wait_for_unit("authentik.service")
     authentik.wait_for_open_port(9000)
-    authentik.wait_until_succeeds("curl -fL http://localhost:9000/if/flow/initial-setup/ >&2")
+    authentik.wait_until_succeeds("curl -fL http://localhost:9000 >&2")
 
     with subtest("Frontend renders"):
-        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000/if/flow/initial-setup/' >&2 &")
+        authentik.succeed("su - alice -c 'firefox --kiosk http://localhost:9000' >&2 &")
         authentik.wait_for_text("${customWelcome}")
         authentik.screenshot("1_rendered_frontend")
 
@@ -113,7 +113,7 @@ pkgs.testers.runNixOSTest {
         authentik.send_key("tab")
         authentik.send_chars("foobar")
         authentik.send_key("ret")
-        authentik.wait_for_text("My applications")
+        authentik.wait_for_text("No Applications available.")
         authentik.send_key("esc")
         authentik.screenshot("2_initial_setup_successful")
 


### PR DESCRIPTION
ChangeLog: https://docs.goauthentik.io/releases/2026.5

The worker's entrypoint got ported to Rust, giving us another entrypoint.

Since both the JS & Go client API are part of the main repo now, the build process had to be ported to building these ourselves in both cases.

Additional flake.lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/da5ad661ba4e5ef59ba743f0d112cbc30e474f32' (2026-05-10)
  → 'github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786' (2026-05-23)
• Updated input 'pyproject-build-systems':
    'github:pyproject-nix/build-system-pkgs/ffaa2161dd5d63e0e94591f86b54fc239660fb2e' (2026-04-20)
  → 'github:pyproject-nix/build-system-pkgs/7bff980f37fc24e09dbc986643719900c139bf12' (2026-05-25)
• Updated input 'pyproject-nix':
    'github:pyproject-nix/pyproject.nix/69f57f27e52a87c54e28138a75ec741cd46663c9' (2026-04-20)
  → 'github:pyproject-nix/pyproject.nix/a228447c3e179d477c1b6246ef3efa8cfe3c469a' (2026-05-16)
• Updated input 'uv2nix':
    'github:pyproject-nix/uv2nix/b48abe99ef639cd100c224898529370e5d935294' (2026-05-13)
  → 'github:pyproject-nix/uv2nix/fdf2a76275d7a9c27deb5d2f2ab33526ac9052ff' (2026-05-22)

---

Deployed successfully to my personal instance.

cc @riotbib @networkException @GeoffreyFrogeye @bartoostveen as potentially interested people.