### PR TITLE
misc: add update script

### DIFF
--- a/update-hashes.sh
+++ b/update-hashes.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x
+
+nix-update --version=skip packages.x86_64-linux.docs --flake
+nix-update --version=skip packages.x86_64-linux.frontend --flake
+nix-update --version=skip packages.x86_64-linux.gopkgs --flake
+nix-update --version=skip packages.x86_64-linux.rust --flake
+nix-update packages.x86_64-linux.terraform-provider-authentik --flake


### PR DESCRIPTION
The version in the flake still needs to be bumped manually, but the hashes now get updated automatically and the terraform provider also has full updates.