### PR TITLE
feat: expose `authentikComponents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Please note that this project is not directly affiliated with the official [auth
 * [minimal-vmtest.nix](./tests/minimal-vmtest.nix)
   A minimal NixOS VM test. Confirms that the services configured by the module start and manually goes through the initial setup flow. Some screenshots are taken during test execution to confirm that the frontend is rendered correctly.
 * [components](./components/default.nix)
-  An overridable scope, including the individual authentik components. An example for how to create a custom scope is provided in [override-scope.nix](./tests/override-scope.nix).
+  An overridable scope, including the individual authentik components. An example for how to create a custom scope is provided in [override-scope.nix](./tests/override-scope.nix) which uses `mkAuthentikScope`. It is used with a package set `pkgs` from either NixOS stable or unstable branch.
+  The attribute `legacyPackages.${system}.authentikComponents` is a shortcut to be used as the instantiation of this function for the pinned `pkgs` in this repository.
 
 ## Usage
 

--- a/flake.nix
+++ b/flake.nix
@@ -149,6 +149,10 @@
             inherit (self.lib.mkAuthentikScope { inherit pkgs; }) authentikComponents;
           in
           {
+            legacyPackages = {
+              authentikComponents = self.lib.mkAuthentikScope { inherit pkgs; };
+            };
+
             packages = {
               inherit (authentikComponents)
                 docs


### PR DESCRIPTION

- Expose `authentikComponents` in `legacyPackages` to be used by the caller for `overrideScope`.
- Added some docs too.

Is it possible to somehow have this feature on the version `2026.5.4` as well? I use this in https://github.com/juspay/services-flake/pull/703.
