### PR TITLE
README: remove warning about flake.lock compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A Nix flake providing a package, NixOS module and basic VM test for [authentik](https://github.com/goauthentik/authentik)
 
-## NixOS compatibilty
-
-This project supports the flake inputs with the revisions specified in the committed `flake.lock` of this repository. Custom overrides of the flake inputs, such as overriding the `nixpkgs` input with `follows`, are not supported per se, as they may easily lead to build or evaluation errors.
-
 ## Important Note
 Please note that this project is not directly affiliated with the official [authentik](https://github.com/goauthentik/authentik) project. Most importantly this means that there is no official support for this packaging and deployment approach. Therefore, please refrain from opening issues for the official project when running into problems with this flake. Feel free to open issues here. If in doubt, please open an issue here first so we can make sure that it's not directly related to this packaging/deployment approach before escalating to the official project.
 


### PR DESCRIPTION
I've been building this on stable for about a year now and this is working pretty well since uv2nix is in use since we're no longer bound as strongly to the python package-set from nixpkgs.

Making this explicit. The positive experiences of one year should be sufficient for that IMHO.

cc @gabyx @MarcelCoding 