### PR TITLE
components/{migrate,manage}: patch shebangs to not depend on /usr/bin/env

### DIFF
--- a/components/manage.nix
+++ b/components/manage.nix
@@ -8,12 +8,13 @@
 runCommandLocal "authentik-manage"
   {
     nativeBuildInputs = [ makeWrapper ];
+    buildInputs = [ authentikComponents.pythonEnv ];
   }
   ''
     mkdir -vp $out/bin
     cp -v ${authentik-src}/manage.py $out/bin/manage.py
 
+    patchShebangs $out/bin
     wrapProgram $out/bin/manage.py \
-      --prefix PATH : ${authentikComponents.pythonEnv}/bin \
       --prefix PYTHONPATH : ${authentikComponents.staticWorkdirDeps}
   ''

--- a/components/migrate.nix
+++ b/components/migrate.nix
@@ -8,6 +8,7 @@
 runCommandLocal "authentik-migrate.py"
   {
     nativeBuildInputs = [ makeWrapper ];
+    buildInputs = [ authentikComponents.pythonEnv ];
   }
   ''
     mkdir -vp $out/bin
@@ -19,6 +20,5 @@ runCommandLocal "authentik-migrate.py"
       'Path(__file__).parent.absolute().glob("system_migrations/*.py")' \
       'Path("${authentikComponents.staticWorkdirDeps}/lifecycle").glob("system_migrations/*.py")'
     wrapProgram $out/bin/migrate.py \
-      --prefix PATH : ${authentikComponents.pythonEnv}/bin \
       --prefix PYTHONPATH : ${authentikComponents.staticWorkdirDeps}
   ''


### PR DESCRIPTION
Closes #162

The correct Python is set via $PATH in the wrapper, however the shebang was still load-bearing inside the wrapped scripts which is an issue in sandboxed runtime environments where this doesn't exist.

Add pythonEnv to the buildInputs and run patchShebangs instead.

cc @gabyx 